### PR TITLE
Automatically update desktop background with build date

### DIFF
--- a/do_backup.sh
+++ b/do_backup.sh
@@ -12,6 +12,18 @@ __EOF__
 # First of all, clean up our image
 sudo apt-get clean
 
+# Update build date
+convert ~/Customisations/Robot1-master.png \
+	-fill "#00afe9" \
+	-draw 'rectangle 0,0,87,25' \
+	-family Sans \
+	-weight bold \
+	-pointsize 10 \
+	+antialias \
+	-fill black \
+	-annotate +2+10 "Build Date:\n`date '+%Y-%m-%d %H:%M'`" \
+	~/Customisations/Robot1.png 
+
 sudo rsync -avxPz --delete \
 	--exclude=lost+found/ \
 	/boot/ \


### PR DESCRIPTION
When running the 'do_backup.sh' script, automatically write the build date onto the desktop background image