### PR TITLE
Removing extraneous spaces from sketches

### DIFF
--- a/Ballet/Ballet.ino
+++ b/Ballet/Ballet.ino
@@ -3,7 +3,7 @@
 
 void loop()
 {
-	// Basic code for the ballet 
+	// Basic code for the ballet
 
 	forward(1000, 255, 255);
 	halt(500);
@@ -40,11 +40,11 @@ void loop()
 	shoogle();
 
 	leftSpin(500, 255);
-	halt(500);  
+	halt(500);
 	shoogle();
 
 	leftSpin(500, 255);
-	halt(500);  
+	halt(500);
 	shoogle();
 
 	leftSpin(3000, 255);
@@ -68,17 +68,4 @@ void shoogle()
 
 		i--;
 	}
-}  
-
-
-
-
-
-
-
-
-
-
-
-
-
+}

--- a/Goal/Goal.ino
+++ b/Goal/Goal.ino
@@ -8,12 +8,12 @@ void loop()
   int midDistance=0;
   int rightDistance=0;
 
-  tiltCentre();  
-  
+  tiltCentre();
+
   pointLeft();
   leftDistance = Ultrasonic();
-    
-  if ( leftDistance <= midDistance && leftDistance <= rightDistance ) 
+
+  if ( leftDistance <= midDistance && leftDistance <= rightDistance )
   {
     //Shoot!
 
@@ -22,11 +22,11 @@ void loop()
   halt(1000);
 
   //Celebrate the goal!
-  stupidCelebration(); 
-  
+  stupidCelebration();
+
   //Have a rest
   halt(5000);
-    
+
 }
 
 //Demonstrate using functions
@@ -51,31 +51,28 @@ void jiggleBot (int repeats)
 void wiggleBot (int repeats)
 {
   int i = 0;
-  
+
   while (i < repeats)
   {
     leftSpin(200, 255);
     rightSpin(400, 255);
     leftSpin(200,255);
-    
+
     i++;
   }
 }
-  
+
 //Demonstrate recursion
 int noddingBot (int repeats)
 {
   tiltUp();
   tiltDown();
   tiltCentre();
-  
+
   if (repeats < 1)
   {
     return 0;
   }
-  
+
   return noddingBot(repeats - 1);
 }
-
-
-

--- a/LineFollow/LineFollow.ino
+++ b/LineFollow/LineFollow.ino
@@ -4,11 +4,14 @@
 
 void loop()
 {
-   
+
   if (leftLineSensor() == BLACK && rightLineSensor() == BLACK )
-  { 
-    //What should I do now?    
-    return;    
+  {
+    //What command should you type in here?
+    return;
   }
-   
+
+
+
+
 }

--- a/Move/Move.ino
+++ b/Move/Move.ino
@@ -4,15 +4,15 @@
 
 void loop()
 {
-    
+
   forward(1000,255,255);
-  
+
   reverse(1000,255,255);
-  
-  leftSpin(1000,255); 
-  
+
+  leftSpin(1000,255);
+
   rightSpin(1000,255);
-    
+
 }
 
 

--- a/Obstacle/Obstacle.ino
+++ b/Obstacle/Obstacle.ino
@@ -7,7 +7,7 @@ void loop()
 
   if ( leftObstacleSensor() == false && rightObstacleSensor() == false )
   {
-    //What command sgould you type in here?
+    //What command should you type in here?
      return;
   }
 

--- a/Obstacle/Obstacle.ino
+++ b/Obstacle/Obstacle.ino
@@ -4,15 +4,14 @@
 
 void loop()
 {
-  
+
   if ( leftObstacleSensor() == false && rightObstacleSensor() == false )
   {
-    //What should I do now?
+    //What command sgould you type in here?
      return;
   }
-     
+
+
+
+
 }
-
-
-
-


### PR DESCRIPTION
Removing leading and trailing spaces from sketches to make copy and pasting for students easier. Also added a gap between the end of the main code and the last curly bracket to stop students from accidentally deleting it. 